### PR TITLE
add fossa and david-dm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/93d283853c41377f8256/maintainability)](https://codeclimate.com/github/Privatix/dapp-smart-contract/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/93d283853c41377f8256/test_coverage)](https://codeclimate.com/github/Privatix/dapp-smart-contract/test_coverage)
+[![Dependency Status](https://david-dm.org/Privatix/dapp-smart-contract.svg)](https://david-dm.org/Privatix/smart-contract)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract?ref=badge_shield)
 
 # Privatix Service Contract

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/93d283853c41377f8256/maintainability)](https://codeclimate.com/github/Privatix/dapp-smart-contract/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/93d283853c41377f8256/test_coverage)](https://codeclimate.com/github/Privatix/dapp-smart-contract/test_coverage)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract?ref=badge_shield)
 
 # Privatix Service Contract
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/93d283853c41377f8256/maintainability)](https://codeclimate.com/github/Privatix/dapp-smart-contract/maintainability)
-[![Dependency Status](https://david-dm.org/Privatix/dapp-smart-contract.svg)](https://david-dm.org/Privatix/dapp-smart-contract)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract?ref=badge_shield)
 
 # Privatix Service Contract

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/93d283853c41377f8256/maintainability)](https://codeclimate.com/github/Privatix/dapp-smart-contract/maintainability)
-[![Dependency Status](https://david-dm.org/Privatix/dapp-smart-contract.svg)](https://david-dm.org/Privatix/smart-contract)
+[![Dependency Status](https://david-dm.org/Privatix/dapp-smart-contract.svg)](https://david-dm.org/Privatix/dapp-smart-contract)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract?ref=badge_shield)
 
 # Privatix Service Contract


### PR DESCRIPTION
Take a look at FOSSA dashboard for `dapp-smart-contract`: https://app.fossa.io/projects/git%2Bgithub.com%2FPrivatix%2Fdapp-smart-contract/

As a policy, I chose "Standard Bundle Distribution": https://fossa.io/docs/policies/overview/
![image](https://user-images.githubusercontent.com/13798583/37602547-9eeede40-2b9d-11e8-93b3-696f55d5aa1f.png)


